### PR TITLE
HotFix: build.gradle fixed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ jar {
     }
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     from sourceSets.test.output
-    exclude 'META-INF/*.md', 'module-info.class', 'screen/*.class'
+    exclude 'META-INF/*.md', 'module-info.class', 'screen/GameScreenTest$TestUpdate.class', 'screen/GameScreenTest$TestUpdate$TestSimulation.class', 'screen/GameScreenTest$TestUpdate$TestSimulation.class', 'screen/GameScreenTest.class'
 }
 
 test {


### PR DESCRIPTION
빌드 시 특정 클래스(Screen.class) 누락되는 버그 핫픽스